### PR TITLE
feat(highlightDefault): Add flag to disable default highlight

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -94,7 +94,7 @@ uis.controller('uiSelectCtrl',
             return angular.equals(this, item);
           }, ctrl.selected);
         } else {
-          ctrl.activeIndex = 0;
+          ctrl.activeIndex = ctrl.disableDefaultHighlight ? -1 : 0;
         }
       }
     }
@@ -122,7 +122,7 @@ uis.controller('uiSelectCtrl',
       ctrl.activeIndex = ctrl.activeIndex >= ctrl.items.length ? 0 : ctrl.activeIndex;
       // ensure that the index is set to zero for tagging variants
       // that where first option is auto-selected
-      if ( ctrl.activeIndex === -1 && ctrl.taggingLabel !== false ) {
+      if ( ctrl.activeIndex === -1 && ctrl.taggingLabel !== false  && ctrl.disableDefaultHighlight !== true) {
         ctrl.activeIndex = 0;
       }
 

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -149,6 +149,10 @@ uis.directive('uiSelect',
           }
         });
 
+        attrs.$observe('disableDefaultHighlight', function() {
+          $select.disableDefaultHighlight = scope.$eval(attrs.disableDefaultHighlight);
+        });
+
         attrs.$observe('spinnerEnabled', function() {
           // $eval() is needed otherwise we get a string instead of a boolean
           var spinnerEnabled = scope.$eval(attrs.spinnerEnabled);

--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -289,7 +289,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
 
         if ( ! KEY.isVerticalMovement(e.which) ) {
           scope.$evalAsync( function () {
-            $select.activeIndex = $select.taggingLabel === false ? -1 : 0;
+            $select.activeIndex = ($select.taggingLabel === false || $select.disableDefaultHighlight) ? -1 : 0;
           });
         }
         // Push a "create new" item into array if there is a search string
@@ -300,7 +300,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
             return;
           }
           // always reset the activeIndex to the first item when tagging
-          $select.activeIndex = $select.taggingLabel === false ? -1 : 0;
+          $select.activeIndex = ($select.taggingLabel === false || $select.disableDefaultHighlight) ? -1 : 0;
           // taggingLabel === false bypasses all of this
           if ($select.taggingLabel === false) return;
 


### PR DESCRIPTION
New flag `disableDefaultHighlight` for `ui-select`. When this flag is `true` the default `activeIndex` will be `-1` instead of `0`.