### PR TITLE
followanalytics/fa-issues#4454 Remove hard coded 50px width on resize

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -552,7 +552,6 @@ uis.controller('uiSelectCtrl',
           return true;
         };
 
-    ctrl.searchInput.css('width', '50px');
     $timeout(function() { //Give tags time to render correctly
       if (sizeWatch === null && !updateIfVisible(calculateContainerWidth())) {
         sizeWatch = $scope.$watch(function() {


### PR DESCRIPTION
Relates to followanalytics/fa-issues#4454

This was making the placeholder hidden and the input box 50px wide when the window would be resized, which is really narrow.
I tested the other select boxes and everything seems to be working fine